### PR TITLE
Retrieve customer prices

### DIFF
--- a/src/PrestashopWebServiceLibrary.php
+++ b/src/PrestashopWebServiceLibrary.php
@@ -350,7 +350,7 @@ class PrestashopWebServiceLibrary
                 $url .= '/'.$options['id'];
             }
 
-            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop','date');
+            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop','date', 'price');
             foreach ($params as $p) {
                 foreach ($options as $k => $o) {
                     if (strpos($k, $p) !== false) {


### PR DESCRIPTION
Adding 'price' to $params-array makes it possible to read customer prices that include taxes or any reductions as described by: 
http://doc.prestashop.com/display/PS15/Chapter+10+-+Price+management